### PR TITLE
fix: Ensure service uses proper delays to avoid conflicts

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Francis Gallagher'
 maintainer_email 'francis@akoova.com'
 license          'MIT'
 description      'Installs and configures incron-next, fork of incron'
-version          '0.3.8'
+version          '0.3.9'
 
 depends 'yum'
 depends 'yum-repoforge'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,7 +24,7 @@ template "/etc/systemd/system/#{node['incron']['service_name']}.service" do
   )
   action :create
   notifies :run, 'execute[systemd-daemon-reload]', :immediately
-  notifies node['incron']['reload_method'], 'service[incrond]'
+  notifies node['incron']['reload_method'], 'service[incrond]', :delayed
 end
 
 execute 'systemd-daemon-reload' do
@@ -35,12 +35,13 @@ end
 service 'incrond' do
   service_name node['incron']['service_name']
   supports :status => true, :restart => true, :reload => node['incron']['reload_method'] == :reload
-  action [:enable, :start]
+  action :enable
+  notifies :start, 'service[incrond]', :delayed
 end
 
 template '/etc/incron.conf' do
   source 'incron.conf.erb'
   mode '0644'
   action :create
-  notifies node['incron']['reload_method'], 'service[incrond]'
+  notifies node['incron']['reload_method'], 'service[incrond]', :delayed
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -25,7 +25,7 @@ describe 'incron-next::default' do
   end
 
   it 'starts the service' do
-    expect(chef_run).to start_service('incrond')
+    expect(chef_run.service('incrond')).to notify('service[incrond]').to(:start).delayed
   end
 
 end


### PR DESCRIPTION
Without correct delay usage, you can run into a conflict on immediate start

service[incrond] (incron-next::default line 35) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '4'
---- Begin output of ["/bin/systemctl", "--system", "start", "incron"] ----
STDOUT:
STDERR: Failed to start incron.service: Transaction for incron.service/start is destructive (multipathd.service has 'stop' job queued, but 'start' is included in transaction).
See system logs and 'systemctl status incron.service' for details.
---- End output of ["/bin/systemctl", "--system", "start", "incron"] ----
Ran ["/bin/systemctl", "--system", "start", "incron"] returned 4